### PR TITLE
Set down baseline info for Factions

### DIFF
--- a/Not classified/readme.txt
+++ b/Not classified/readme.txt
@@ -1,3 +1,6 @@
-####################
-# Work in progress #
-####################
+### NOT CLASSIFIED ###
+
+These documents are PUBLIC knowledge, but not COMMON knowledge among those in the BEESTATION universe.
+In other words, this is knowledge that has been made available, but is not known by everyone.
+Due to the nature of these documents, they may or may not be completely accurate. This is just a collection of
+knowledge that has been obtained. It may be incorrect and is subject to change.

--- a/Public Canon/General List of Factions.txt
+++ b/Public Canon/General List of Factions.txt
@@ -1,0 +1,42 @@
+--- GENERAL LIST OF FACTIONS ---
+
+This list encompasses general information about the various factions of Beestation's Lore.
+If a faction is added to the lore, make sure to add them to the list.
+
+--- NANOTRASEN ---
+
+An intergalactic megacorporation with vast reach and deep pockets.
+Their current focus is in regards to a strange material known as 'Plasma' that can only be found on the planet 'Lavaland'.
+To further their research, they have built two space stations in orbit of Planet Lavaland.
+These stations are codenamed 'GOLDEN' and 'SAGE'.
+Due to their influence, there are many that would wish them harm.
+
+
+--- THE SYNDICATE ---
+
+Intel on the organization that refers to themselveas as 'The Syndicate' is sparse and often conflicting.
+Some intelligence claims that they are a privatized union, others claim that they are a separate, rival megacorporation.
+
+The only confirmed intel is this; they have sleeper agents that have infiltrated Nanotrasen in nearly every department,
+awaiting their orders. Such commands may be something as simple as stealing documents or objects, while other objectives may include assassintation of personnel.
+They also have dedicated Nuclear Operatives, heavily armed and with a single-minded dedication to obtaining one of Nanotrasen's nuclear authentication disks
+in order to detonate a nuclear bomb aboard the station, and they are willing to ruthlessly and brutally cleave a path through anyone and anything that gets in their way.
+
+One thing is clear; they are the sworn enemies of Nanotrasen, and they are dedicating every resource at their disposal toward its destruction.
+
+
+--- CHANGELINGS ---
+
+Changelings are an alien race known for their incredible stealth and lethality.
+Utilizing their ability to copy genetic information and become a spitting image of whomever they have copied, they are often used as infiltrators
+by the Syndicate; but other factions may make use of them as well, and some changelings may oppose Nanotrasen for reasons of their own.
+
+Their unique anatomy and their incredible regenerative abilities makes them a force to be reckoned with; the mere mention
+of Changelings or 'lings' is enough to sow panic and mistrust among the crew.
+
+
+--- THE WIZARD FEDERATION ---
+
+The ancient art of magic, thought long ago to be nothing more than fantasy, has proven itself to be real in a very, very potent way.
+The Wizard Fedaration is a group of magi dedicated to the preservation and usage of magic.
+They are currently neutral, but infrequently bother Nanotrasen's space stations for some reason or another.

--- a/Public Canon/General List of Factions.txt
+++ b/Public Canon/General List of Factions.txt
@@ -5,11 +5,10 @@ If a faction is added to the lore, make sure to add them to the list.
 
 --- NANOTRASEN ---
 
-An intergalactic megacorporation with vast reach and deep pockets.
-Their current focus is in regards to a strange material known as 'Plasma' that can only be found on the planet 'Lavaland'.
-To further their research, they have built two space stations in orbit of Planet Lavaland.
-These stations are codenamed 'GOLDEN' and 'SAGE'.
-Due to their influence, there are many that would wish them harm.
+A group of some sort with interest in researching advanced technologies.
+Their current focus is on a strange material known as Plasma.
+To this end, they have dedicated resources to research of Plasma, including at least one space station.
+There are many who seek to exploit them for various reasons.
 
 
 --- THE SYNDICATE ---
@@ -37,6 +36,27 @@ of Changelings or 'lings' is enough to sow panic and mistrust among the crew.
 
 --- THE WIZARD FEDERATION ---
 
-The ancient art of magic, thought long ago to be nothing more than fantasy, has proven itself to be real in a very, very potent way.
-The Wizard Fedaration is a group of magi dedicated to the preservation and usage of magic.
-They are currently neutral, but infrequently bother Nanotrasen's space stations for some reason or another.
+The mysterious force referred to as 'magic' has perplexed many scientists since its discovery.
+Details about this strange and seemingly logic defying power are scarce.
+Those who are most knowledgable in regards to magic and it's usage belong to the Wizard Federation.
+
+--- THE BLOOD CULT OF NAR'SIE ---
+
+A group of fanatical cultists who seek to bring their deity, an eldritch entity known as Nar'Sie,
+through the veil and into our universe by means of bloody rituals and forcible conversion.
+
+They are constantly at odds with an opposing cult known as the Clockwork Cult of Ratvar.
+
+--- THE CLOCKWORK CULT OF RATVAR ---
+
+A group of fanatical cultists who seek to bring their deity, an eldritch entity known as Ratvar,
+through the veil and into our universe by means of mechanical interference and forcible conversion.
+
+They are constantly at odds with an opposing cult known as the Blood Cult of Nar'Sie.
+
+--- THE ABDUCTORS ---
+
+The Abductors are a telepathic alien race interested in experimentation.
+Unfortunately, their lack of knowledge of common galactic customs means they have no concept of 'consent'
+and often abduct unwilling crewmembers to experiment on.
+

--- a/Public Canon/To-Do.txt
+++ b/Public Canon/To-Do.txt
@@ -2,5 +2,10 @@
 
 !Assemble complete list of factions
  !Write detailed lore pages about each faction
- >Determine each faction's motivations, goals, and relations with NT
+	(NOT in story format- there needs to be a 'History of [FACTION] with their chronology and important events.)
+ 
+ >Determine each faction's basic motivations, goals, and relations with Nanotrasen
+ >Determine if there are factions that have relations with each other
+ (E.G. The Clockwork Cult of Ratvar and the Blood Cult of Nar'sie)
+
 

--- a/Public Canon/To-Do.txt
+++ b/Public Canon/To-Do.txt
@@ -1,0 +1,6 @@
+### TO DO ###
+
+!Assemble complete list of factions
+ !Write detailed lore pages about each faction
+ >Determine each faction's motivations, goals, and relations with NT
+

--- a/Public Canon/readme.txt
+++ b/Public Canon/readme.txt
@@ -1,3 +1,6 @@
-####################
-# Work in progress #
-####################
+### PUBLIC CANON ###
+
+These documents are common knowledge among those in the BEESTATION universe.
+In other words, this is knowledge that has been made available and is known by most people in general.
+Due to the nature of these documents, they may or may not be completely accurate. This is just a collection of
+knowledge that has been obtained. It may be incorrect in-universe due to a lack of complete information.

--- a/Secret Canon/readme.txt
+++ b/Secret Canon/readme.txt
@@ -1,3 +1,13 @@
-####################
-# Work in progress #
-####################
+### SECRET CANON ###
+
+This is everything that is known to be FACT in regards to factions and events and will often serve as a reference
+to further lore additions and changes. 
+NOT ALL OF THIS INFORMATION IS PUBLIC- Public knowledge is allowed to be incorrect due to lack of information.
+This is everything that has been determined to be canonical, and may include information that is not public knowledge.
+
+Referring to this should only be used if there is a conflict between something that is attempting to be made canon
+and actual canon knowledge (which can be found here). In case of conflict, generally established canon will win over
+attempted alterations, barring extreme circumstances.
+
+Referring to things in this area that is -NOT- public knowledge (barring permissable exceptions) 
+is considered metaknowledge and is frowned upon significantly.

--- a/TODO.txt
+++ b/TODO.txt
@@ -18,3 +18,11 @@
  
 !Make some writing guidelines for this project
  !Put some guidelines them in those readme.txt files and write what's supposed to be in those folders
+	// Work in Progress. -CraftmasterMatt
+
+!Flesh out Factions information.
+  >Determime relations between factions
+  >Determine faction motivations
+  >Determion faction chronology/timeline of events
+  
+!Set concrete timeline (What time do the events of the game take place?)


### PR DESCRIPTION
This serves as a foundation for information and lore about the various factions, such as NT, Syndicate, Changelings, and the Wizard Federation.

Changes:
Adds a 'Factions' folder for dedicated lore in regards to factions- each faction should be given its own folder.
Lore that pertains to multiple factions simultaneously should be put in a 'misc' folder
Adds a document with general information about the factions- how they interact with NT and whether they are friendly, neutral, or hostile; this page can be updated with additional factions (such as the Ashwalkers, Free Golems, cult of Nar'Sie, etc) as needed.

Reason for adding:
This will assist in the development of Beestation's Lore by allowing for a place for lore to be written in regards to each faction. It will also be easily expandable in the future.
In other words, it helps us make our lore more distinct from NV.